### PR TITLE
Adding deferral function to App-Auto-Patch

### DIFF
--- a/App-Auto-Patch-via-Dialog.zsh
+++ b/App-Auto-Patch-via-Dialog.zsh
@@ -118,7 +118,7 @@
 #   Version 2.0.0rc1, 11.07.2023 Robert Schroeder (@robjschroeder)
 #   - Adjusting all references of `MacAdmins Slack)` to `MacAdmins Slack )` in an effor to fix the Slack label coming up as `Asana` (thanks @TechTrekkie)
 #
-#   Version 2.0.0rc2, 11.27.2023 Andrew Spokes (@techtrekkie)
+#   Version 2.0.0rc1-A, 11.27.2023 Andrew Spokes (@techtrekkie)
 #   - Added the ability to allow user to defer installing updates using the 'maxDeferrals' variable. A value of 'disabled' will not display the deferral prompt
 # 
 ####################################################################################################
@@ -133,7 +133,7 @@
 # Script Version and Jamf Pro Script Parameters
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-scriptVersion="2.0.0rc1"
+scriptVersion="2.0.0rc1-A"
 scriptFunctionalName="App Auto-Patch"
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 

--- a/App-Auto-Patch-via-Dialog.zsh
+++ b/App-Auto-Patch-via-Dialog.zsh
@@ -154,7 +154,7 @@ debugMode="${11:-"false"}"                                                    	#
 unattendedExitSeconds="60"							# Number of seconds to wait until a kill Dialog command is sent
 swiftDialogMinimumRequiredVersion="2.3.2.4726"					# Minimum version of swiftDialog required to use workflow
 removeInstallomatorPath="true"                                                  # Remove Installomator after App Auto-Patch is completed [ true | false (default) ]
-maxDeferrals="3"                                                                # Number of times a user is allowed to defer before forced to intall updates. A value of "Disabled" will not display the deferral prompt
+maxDeferrals="Disabled"                                                         # Number of times a user is allowed to defer before forced to intall updates. A value of "Disabled" will not display the deferral prompt
 deferralTimer=3600                                                              # Time given to user to respond to deferral prompt if enabled
 deferralTimerAction="Defer"                                                     # What happens when the deferral timer expires [ Defer | Continue ]
 

--- a/App-Auto-Patch-via-Dialog.zsh
+++ b/App-Auto-Patch-via-Dialog.zsh
@@ -124,6 +124,7 @@
 #   Version 2.0.0rc1-B, 11.29.2023 Andrew Spokes (@techtrekkie)
 #   - Changed deferral plist to use the aapPath folder to facilitate creating an EA to populate remaining deferrals in Jamf
 #   - Added deferralTimerAction to indicate whether the default action when the timer expires is to Defer or continue with installs
+#   - Moved deferral reset to after installation step to confirm the user completed the process without skipping it (force shutdown/reboot)
 # 
 ####################################################################################################
 
@@ -1426,14 +1427,11 @@ You have $remainingDeferrals deferral(s) remaining."
                 notice "There are $remainingDeferrals deferrals left"
                 exit 0
             else
-                notice "Timer Expired and Action not set to Defer... Resetting Deferrals and moving to Installation step"
-                defaults write $aapAutoPatchDeferralFile remainingDeferrals $maxDeferrals
+                notice "Timer Expired and Action not set to Defer... Moving to Installation step"
             fi
             
         else
-            notice "Resetting Deferrals and moving to Installation step"
-            defaults write $aapAutoPatchDeferralFile remainingDeferrals $maxDeferrals
-            
+            notice "Moving to Installation step"
         fi
     fi
 
@@ -1454,6 +1452,8 @@ if [[ ${#countOfElementsArray[@]} -gt 0 ]]; then
     infoOut "Passing ${numberOfUpdates} labels to Installomator: $queuedLabelsArray"
     #numberOfListedItems=$((${#displayNames[@]}))
     doInstallations
+    infoOut "Installs Complete... Resetting Deferrals"
+    defaults write $aapAutoPatchDeferralFile remainingDeferrals $maxDeferrals
 else
     infoOut "All apps up to date. Nothing to do." # inbox zero
     removeInstallomator 

--- a/App-Auto-Patch-via-Dialog.zsh
+++ b/App-Auto-Patch-via-Dialog.zsh
@@ -117,6 +117,9 @@
 #
 #   Version 2.0.0rc1, 11.07.2023 Robert Schroeder (@robjschroeder)
 #   - Adjusting all references of `MacAdmins Slack)` to `MacAdmins Slack )` in an effor to fix the Slack label coming up as `Asana` (thanks @TechTrekkie)
+#
+#   Version 2.0.0rc2, 11.27.2023 Andrew Spokes (@techtrekkie)
+#   - Added the ability to allow user to defer installing updates using the 'maxDeferrals' variable. A value of 'disabled' will not display the deferral prompt
 # 
 ####################################################################################################
 
@@ -136,7 +139,7 @@ export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 
 scriptLog="${4:-"/var/log/com.company.log"}"                                    # Parameter 4: Script Log Location [ /var/log/com.company.log ] (i.e., Your organization's default location for client-side logs)
 useOverlayIcon="${5:="true"}"                                                   # Parameter 5: Toggles swiftDialog to use an overlay icon [ true (default) | false ]
-interactiveMode="${6:="1"}"                                                     # Parameter 6: Interactive Mode [ 0 (Completely Silent) | 1 (Silent Discovery, Interactive Patching) | 2 (Full Interactive) ]
+interactiveMode="${6:="2"}"                                                     # Parameter 6: Interactive Mode [ 0 (Completely Silent) | 1 (Silent Discovery, Interactive Patching) | 2 (Full Interactive) ]
 ignoredLabels="${7:=""}"                                                        # Parameter 7: A space-separated list of Installomator labels to ignore (i.e., "microsoft* googlechrome* jamfconnect zoom* 1password* firefox* swiftdialog")
 requiredLabels="${8:=""}"                                                       # Parameter 8: A space-separated list of required Installomator labels (i.e., "firefoxpkg_intl")
 outdatedOsAction="${9:-"/System/Library/CoreServices/Software Update.app"}"     # Parameter 9: Outdated OS Action [ /System/Library/CoreServices/Software Update.app (default) | jamfselfservice://content?entity=policy&id=117&action=view ] (i.e., Jamf Pro Self Service policy ID for operating system upgrades)
@@ -146,8 +149,8 @@ debugMode="${11:-"false"}"                                                    	#
 unattendedExitSeconds="60"							# Number of seconds to wait until a kill Dialog command is sent
 swiftDialogMinimumRequiredVersion="2.3.2.4726"					# Minimum version of swiftDialog required to use workflow
 removeInstallomatorPath="true"                                                  # Remove Installomator after App Auto-Patch is completed [ true | false (default) ]
-maxDeferrals="3"                                                                # Number of times a user is allowed to defer before forced to intall updates. Disabled will not display this prompt
-deferralTimer=86400 #86400 = 24 hours                                           # Time given to user to respond to deferral prompt if enabled
+maxDeferrals="3"                                                                # Number of times a user is allowed to defer before forced to intall updates. A value of "Disabled" will not display the deferral prompt
+deferralTimer=3600                                                              # Time given to user to respond to deferral prompt if enabled
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #

--- a/App-Auto-Patch-via-Dialog.zsh
+++ b/App-Auto-Patch-via-Dialog.zsh
@@ -144,7 +144,7 @@ export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 
 scriptLog="${4:-"/var/log/com.company.log"}"                                    # Parameter 4: Script Log Location [ /var/log/com.company.log ] (i.e., Your organization's default location for client-side logs)
 useOverlayIcon="${5:="true"}"                                                   # Parameter 5: Toggles swiftDialog to use an overlay icon [ true (default) | false ]
-interactiveMode="${6:="1"}"                                                     # Parameter 6: Interactive Mode [ 0 (Completely Silent) | 1 (Silent Discovery, Interactive Patching) | 2 (Full Interactive) ]
+interactiveMode="${6:="2"}"                                                     # Parameter 6: Interactive Mode [ 0 (Completely Silent) | 1 (Silent Discovery, Interactive Patching) | 2 (Full Interactive) ]
 ignoredLabels="${7:=""}"                                                        # Parameter 7: A space-separated list of Installomator labels to ignore (i.e., "microsoft* googlechrome* jamfconnect zoom* 1password* firefox* swiftdialog")
 requiredLabels="${8:=""}"                                                       # Parameter 8: A space-separated list of required Installomator labels (i.e., "firefoxpkg_intl")
 outdatedOsAction="${9:-"/System/Library/CoreServices/Software Update.app"}"     # Parameter 9: Outdated OS Action [ /System/Library/CoreServices/Software Update.app (default) | jamfselfservice://content?entity=policy&id=117&action=view ] (i.e., Jamf Pro Self Service policy ID for operating system upgrades)


### PR DESCRIPTION
This is to merge the fork that I added deferral functionality to. This is the same as the latest version I last sent you a couple of weeks ago.

Just a recap for the PR documentation:
This new function allows you to display a notification to the user that updates are available after the discovery stage, and allows the user to defer the installation until a later time. It's recommended to set interactiveMode=1 if the deferral function is enabled so the discovery stage is done silently prior to notifying the user that updates are available to install.

The deferral functionality is disabled by default using the variable `maxDeferrals="Disabled," so the script functions normally unless that variable is specifically given a numerical value. 


Variables: 
- maxDeferrals: Set to Disabled as default, set to a numerical value to prompt a user to install patches with the option to defer by the number set in this variable
- deferralTimer: The number of seconds the deferral prompt is displayed before automatic action is taken
- deferralTimerAction: The action to take when the deferralTimer expires (Defer or Continue)

Config files:
- aapAutoPatchDeferralFile: used to store the maxDeferrals and remainingDeferrals values

Screenshot of the deferral prompt: 
![image](https://github.com/robjschroeder/App-Auto-Patch/assets/132794591/c2122d5a-756c-4485-ae80-a302676b1c0e)
