### PR TITLE
Update AAP-Activator instructions and add two new parameters to AAP-Activator sript

### DIFF
--- a/AAP-Activator/AAP-Activator.zsh
+++ b/AAP-Activator/AAP-Activator.zsh
@@ -15,7 +15,7 @@
 #   - Added makePath function to correct config file/folder permissions (Thanks @robjschroeder !)
 #
 #   Version 0.0.3, 12.19.2023, Andrew Spokes (@TechTrekkie)
-#   - Changed AAP Jamf Policy trigger to use variable populated by Jamf Pro Script parameter #5
+#   - Changed AAP Jamf Policy trigger to use variable populated by Jamf Pro Script parameter #5, added parameter #6 for days until status reset
 #
 ####################################################################################################
 #
@@ -40,6 +40,7 @@ export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 
 scriptLog="${4:-"/var/log/com.company.aap-activator.log"}"                                    # Parameter 4: Script Log Location [ /var/log/com.company.log ] (i.e., Your organization's default location for client-side logs)
 aapPolicyTrigger="${5:-"AppAutoPatch"}"                                                       # Parameter 5: The trigger used to call the App Auto-Patch Jamf Policy [ex: AppAutoPatch ]
+daysUntilReset="${6:-7}"								      # Parameter 6: The number of days until the activator resets the patching status to False
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Various Feature Variables
@@ -90,7 +91,7 @@ echo "Weekly Patching Status Date: $weeklyPatchingStatusDate"
 echo "Current Date: $CurrentDate"
 echo "Days Since Status Date: $DaysSinceStatus"
 
-if [ ${DaysSinceStatus} -ge 7 ]; then
+if [ ${DaysSinceStatus} -ge $daysUntilReset ]; then
 	echo "Resetting Weekly Completion Status to False"
 	defaults write $aapAutoPatchDeferralFile AAPWeeklyPatching -bool false
 	defaults write $aapAutoPatchDeferralFile AAPWeeklyPatchingStatusDate "$CurrentDate"

--- a/AAP-Activator/AAP-Activator.zsh
+++ b/AAP-Activator/AAP-Activator.zsh
@@ -14,6 +14,9 @@
 #   Version 0.0.2, 12.14.2023, Andrew Spokes (@TechTrekkie)
 #   - Added makePath function to correct config file/folder permissions (Thanks @robjschroeder !)
 #
+#   Version 0.0.3, 12.19.2023, Andrew Spokes (@TechTrekkie)
+#   - Changed AAP Jamf Policy trigger to use variable populated by Jamf Pro Script parameter #5
+#
 ####################################################################################################
 #
 # The purpose of this script is to run as a precursor to the App Auto-Patch scripts in order to
@@ -31,11 +34,12 @@
 # Script Version and Jamf Pro Script Parameters
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-scriptVersion="0.0.1"
+scriptVersion="0.0.3"
 scriptFunctionalName="App Auto-Patch Activator"
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 
 scriptLog="${4:-"/var/log/com.company.aap-activator.log"}"                                    # Parameter 4: Script Log Location [ /var/log/com.company.log ] (i.e., Your organization's default location for client-side logs)
+aapPolicyTrigger="${5:-"AppAutoPatch"}"                                                       # Parameter 5: The trigger used to call the App Auto-Patch Jamf Policy [ex: AppAutoPatch ]
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Various Feature Variables
@@ -96,7 +100,7 @@ fi
 
 if [[  $weeklyPatchingComplete == 0 ]]; then
 	echo "Executing App Auto-Patch"
-	/usr/local/bin/jamf policy -trigger AppAutoPatch
+	/usr/local/bin/jamf policy -trigger $aapPolicyTrigger
 elif [[  $weeklyPatchingComplete == 1 ]]; then
 	echo "Weekly Patching Complete... Exiting"
 	exit 0
@@ -105,6 +109,6 @@ else
 	defaults write $aapAutoPatchDeferralFile AAPWeeklyPatching -bool false
 	defaults write $aapAutoPatchDeferralFile AAPWeeklyPatchingStatusDate "$CurrentDate"
 	weeklyPatchingComplete=$(defaults read $aapAutoPatchDeferralFile AAPWeeklyPatching)
-	/usr/local/bin/jamf policy -trigger AppAutoPatch
+	/usr/local/bin/jamf policy -trigger $aapPolicyTrigger
 fi
 	

--- a/AAP-Activator/README.md
+++ b/AAP-Activator/README.md
@@ -29,3 +29,4 @@ AAPWeeklyPatchingStatusDate (datetime) - This gets set with the date/time that A
    * Set the execution frequency to Once Every Day
    * Populate Parameter #4 with your log location
    * Populate Parameter #5 with the App Auto-Patch policy trigger from step #1
+   * Populate Parameter #6 with The number of days until the activator resets the patching status to False (for a weekly reset, set to 7)

--- a/AAP-Activator/README.md
+++ b/AAP-Activator/README.md
@@ -20,10 +20,12 @@ AAPWeeklyPatching (True | False) - This is set to False by default which signals
 AAPWeeklyPatchingStatusDate (datetime) - This gets set with the date/time that AAP-Activator first runs and is used to calculate how many days have passed for a weekly patching cadence
 
 ## Setup
-1. Set your App-Auto-Patch Jamf Policy to a frequency of “ongoing” and set a custom trigger (ex: AppAutoPatch)
+1. Set your App Auto-Patch Jamf Policy to a frequency of “ongoing” and set a custom trigger (ex: AppAutoPatch)
 
-2. Import the AAP-Activator Script to your Jamf Pro instance and modify the code on lines 89 and 98 to use the trigger from Step #1
+2. Import the AAP-Activator Script to your Jamf Pro instance and set the Jamf Pro Script parameter names to match Parameter #4 and #5 from the script (#4: Log Location, #5 AAP Jamf Policy Trigger)
 
 3. Create a Jamf Pro policy that uses the AAP-Activator Script
    * Set the Trigger to Recurring Check-In
    * Set the execution frequency to Once Every Day
+   * Populate Parameter #4 with your log location
+   * Populate Parameter #5 with the App Auto-Patch policy trigger from step #1

--- a/AAP-Activator/README.md
+++ b/AAP-Activator/README.md
@@ -14,9 +14,6 @@ This script writes two variables to a configuration file:
 ## Configuration
 The APP-Activator utilizes the existing AppAutoPatchDeferrals.plist configuration file created in the App-Auto-Patch script and works regardless if the deferral workflow is being utilized or not
 
-**Note**: You will need to add some modified code to the App-Auto-Patch-via-Dialog.zsh script in order for AAP-Activator to work. I have a modified version in this repo that you can copy the changes from between lines 1469 and 1479
-This modified code will set the AAPWeeklyPatching value to True either when patching has been completed successfully, or if no apps are available to patch
-
 Two values are set in the config file:
 
 AAPWeeklyPatching (True | False) - This is set to False by default which signals AAP-Activator to trigger the App-Auto-Patch script
@@ -24,7 +21,6 @@ AAPWeeklyPatchingStatusDate (datetime) - This gets set with the date/time that A
 
 ## Setup
 1. Set your App-Auto-Patch Jamf Policy to a frequency of “ongoing” and set a custom trigger (ex: AppAutoPatch)
-   * Note: You must be using the modified App-Auto-Patch-via-Dialog.zsh script mentioned above.  
 
 2. Import the AAP-Activator Script to your Jamf Pro instance and modify the code on lines 89 and 98 to use the trigger from Step #1
 


### PR DESCRIPTION
Removing notes about using the modified AAP script since changes have been merged into the main repo and its no longer necessary to use the modified version from my fork