### PR TITLE
AAP-Activator 1.1.0

### DIFF
--- a/AAP-Activator/AAP-Activator.zsh
+++ b/AAP-Activator/AAP-Activator.zsh
@@ -23,6 +23,11 @@
 #	- Updated logic to populate AAPActivatorFlag to populate variable in AAP script so a single script can be used for both Automated and Self Service workflows
 #	- Added logging including debugging
 #
+#   Version 1.1.0, 02.12.2024, Andrew Spokes (@TechTrekkie)
+#	- Added parameter to calculate the start date of the patch week to a specific day of the week. ex: Weekly patching starts on Tuesday but a Mac doesn't check in until Wednesday, the date will still be set to that Tuesdays date
+#	- Added Display Assertion function in addition to maxDisplayAssertionCount variable to set the max amount of times to defer for active disply assertion
+#	- Added AAPDisplayAssertionCount to PLIST to use for Extension Attribute/Smart Group to identify Macs with active display assertion deferrals (scope or a more frequent AAP Trigger)
+#
 ####################################################################################################
 #
 # The purpose of this script is to run as a precursor to the App Auto-Patch scripts in order to
@@ -40,21 +45,41 @@
 # Script Version and Jamf Pro Script Parameters
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-scriptVersion="1.0.0"
+scriptVersion="1.1.0"
 scriptFunctionalName="App Auto-Patch Activator"
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 
-scriptLog="${4:-"/var/log/com.company.aap-activator.log"}"                                    	# Parameter 4: Script Log Location [ /var/log/com.company.log ] (i.e., Your organization's default location for client-side logs)
-aapPolicyTrigger="${5:-"AppAutoPatch"}"                                                       	# Parameter 5: The trigger used to call the App Auto-Patch Jamf Policy [ex: AppAutoPatch ]
-daysUntilReset="${6:-7}"									# Parameter 6: The number of days until the activator resets the patching status to False
+scriptLog="${4:-"/var/log/com.company.aap-activator.log"}"                              # Parameter 4: Script Log Location [ /var/log/com.company.log ] (i.e., Your organization's default location for client-side logs)
+aapPolicyTrigger="${5:-"AppAutoPatch"}"                                                 # Parameter 5: The trigger used to call the App Auto-Patch Jamf Policy [ex: AppAutoPatch ]
+daysUntilReset="${6:-7}"																# Parameter 6: The number of days until the activator resets the patching status to False
 debugMode="${11:-"false"}"                                                      		# Parameter 11: Debug Mode [ true | false (default) | verbose ] Verbose adds additional logging, debug turns Installomator script to DEBUG 2, false for production
+
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Various Feature Variables
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
+patch_week_start_day=""																	# Patch Week Start Day of Week (1-7, blank to disable): The day of week to set the start date for weekly patching: (1=Mon 2=Tue...7=Sun)
+maxDisplayAssertionCount=""																# The maximum number of deferred attempts from Display Assertions (Integer, blank to disable)
+
 CurrentDate=$(date +"%Y-%m-%d")
 CurrentDateEpoch=$(date -j -f "%Y-%m-%d" "$CurrentDate" "+%s")
+
+#### Calculate Patch Week Start Date ####
+if [[ $patch_week_start_day != "" ]]; then
+# Get the current day of the week
+current_day=$(date +%u)
+# Calculate the number of days to subtract to get to the most recent patch week start date
+days_to_subtract=$((current_day - $patch_week_start_day))
+if [ $days_to_subtract -lt 0 ]; then
+	days_to_subtract=$((days_to_subtract + 7))
+fi
+
+# Calculate the date of the most recent patch week start date
+Patch_Week_Start_Date=$(date -v "-$days_to_subtract"d "+%Y-%m-%d")
+else
+	Patch_Week_Start_Date=$CurrentDate
+fi 
 
 ### Configuration PLIST variables ###
 
@@ -165,14 +190,40 @@ fi
 preFlight "Complete"
 
 
+hasDisplaySleepAssertion() {
+	# Get the names of all apps with active display sleep assertions
+	local apps="$(/usr/bin/pmset -g assertions | /usr/bin/awk '/NoDisplaySleepAssertion | PreventUserIdleDisplaySleep/ && match($0,/\(.+\)/) && ! /coreaudiod/ {gsub(/^.*\(/,"",$0); gsub(/\).*$/,"",$0); print};')"
+	
+	if [[ ! "${apps}" ]]; then
+		# No display sleep assertions detected
+		return 1
+	fi
+	
+	# Create an array of apps that need to be ignored
+	local ignore_array=("${(@s/,/)IGNORE_DND_APPS}")
+	
+	for app in ${(f)apps}; do
+		if (( ! ${ignore_array[(Ie)${app}]} )); then
+			# Relevant app with display sleep assertion detected
+			#printlog "Display sleep assertion detected by ${app}."
+			infoOut  "Display sleep assertion detected by ${app}."
+			return 0
+		fi
+	done
+	
+	# No relevant display sleep assertion detected
+	return 1
+}
+
 
 if [[ ! -f $aapAutoPatchDeferralFile ]]; then
 	debug "AAP Status configuration profile does not exist, creating now and setting patching to false"
 	makePath "$aapAutoPatchDeferralFile"
 	defaults write $aapAutoPatchDeferralFile AAPWeeklyPatching -bool false
-	defaults write $aapAutoPatchDeferralFile AAPWeeklyPatchingStatusDate "$CurrentDate"
+	defaults write $aapAutoPatchDeferralFile AAPWeeklyPatchingStatusDate "$Patch_Week_Start_Date"
 	debug "Setting AAPActivatorFlag to True"
 	defaults write $aapAutoPatchDeferralFile AAPActivatorFlag -bool true
+	defaults write $aapAutoPatchDeferralFile AAPDisplayAssertionCount 0
 else
 	debug "Setting AAPActivatorFlag to True"
 	defaults write $aapAutoPatchDeferralFile AAPActivatorFlag -bool true
@@ -182,13 +233,14 @@ fi
 
 weeklyPatchingComplete=$(defaults read $aapAutoPatchDeferralFile AAPWeeklyPatching)
 weeklyPatchingStatusDate=$(defaults read $aapAutoPatchDeferralFile AAPWeeklyPatchingStatusDate)
+DisplayAssertionCount=$(defaults read $aapAutoPatchDeferralFile AAPDisplayAssertionCount)
 
 
 if [[ -z $weeklyPatchingComplete || -z $weeklyPatchingStatusDate ]]; then
 	debug "Patching Completion Status or Start Date not set, setting values"
 	makePath "$aapAutoPatchDeferralFile"
 	defaults write $aapAutoPatchDeferralFile AAPWeeklyPatching -bool false
-	defaults write $aapAutoPatchDeferralFile AAPWeeklyPatchingStatusDate "$CurrentDate"
+	defaults write $aapAutoPatchDeferralFile AAPWeeklyPatchingStatusDate "$Patch_Week_Start_Date"
 	weeklyPatchingComplete=$(defaults read $aapAutoPatchDeferralFile AAPWeeklyPatching)
 	weeklyPatchingStatusDate=$(defaults read $aapAutoPatchDeferralFile AAPWeeklyPatchingStatusDate)
 fi
@@ -204,23 +256,41 @@ infoOut "Current Date: $CurrentDate"
 infoOut "Days Since Patching Start Date: $DaysSinceStatus"
 
 if [ ${DaysSinceStatus} -ge $daysUntilReset ]; then
-	debug "Resetting Completion Status to False"
+	infoOut "Resetting Completion Status to False"
 	defaults write $aapAutoPatchDeferralFile AAPWeeklyPatching -bool false
-	defaults write $aapAutoPatchDeferralFile AAPWeeklyPatchingStatusDate "$CurrentDate"
+	infoOut "Setting Patch Week Start Date as $Patch_Week_Start_Date"
+	defaults write $aapAutoPatchDeferralFile AAPWeeklyPatchingStatusDate "$Patch_Week_Start_Date"
 	weeklyPatchingComplete=$(defaults read $aapAutoPatchDeferralFile AAPWeeklyPatching)
+	defaults write $aapAutoPatchDeferralFile AAPDisplayAssertionCount 0
 fi
-	
 
-if [[  $weeklyPatchingComplete == 0 ]]; then
+if hasDisplaySleepAssertion; then
+	infoOut  "active display sleep assertion detected"
+	DisplayAssertionCount=$((DisplayAssertionCount+1))
+	defaults write $aapAutoPatchDeferralFile AAPDisplayAssertionCount $DisplayAssertionCount
+	infoOut "Display Assertion Count: $DisplayAssertionCount"
+	DisplayAssertionCount=$(defaults read $aapAutoPatchDeferralFile AAPDisplayAssertionCount)
+else
+	infoOut  "No Assertions Detected"
+	defaults write $aapAutoPatchDeferralFile AAPDisplayAssertionCount 0
+	DisplayAssertionCount=$(defaults read $aapAutoPatchDeferralFile AAPDisplayAssertionCount)
+fi
+
+
+if [[  $weeklyPatchingComplete == 1 ]]; then
+	infoOut "Patching Status already Complete... Exiting"
+	defaults write $aapAutoPatchDeferralFile AAPDisplayAssertionCount 0
+	exit 0
+elif [[ ${DisplayAssertionCount} -ge 1 && ${DisplayAssertionCount} -le $maxDisplayAssertionCount ]]; then
+	infoOut "Display Assertions Detected. Assertion Count $DisplayAssertionCount .... Exiting"
+	exit 0
+elif [[  $weeklyPatchingComplete == 0 ]]; then
 	infoOut "Executing App Auto-Patch"
 	/usr/local/bin/jamf policy -trigger $aapPolicyTrigger
-elif [[  $weeklyPatchingComplete == 1 ]]; then
-	infoOut "Patching Status already Complete... Exiting"
-	exit 0
 else
 	debug "Unknown Status... Setting status to False"
 	defaults write $aapAutoPatchDeferralFile AAPWeeklyPatching -bool false
-	defaults write $aapAutoPatchDeferralFile AAPWeeklyPatchingStatusDate "$CurrentDate"
+	defaults write $aapAutoPatchDeferralFile AAPWeeklyPatchingStatusDate "$Patch_Week_Start_Date"
 	weeklyPatchingComplete=$(defaults read $aapAutoPatchDeferralFile AAPWeeklyPatching)
 	infoOut "Executing App Auto-Patch"
 	/usr/local/bin/jamf policy -trigger $aapPolicyTrigger


### PR DESCRIPTION
- Added parameter to calculate the start date of the patch week to a specific day of the week. ex: Weekly patching starts on Tuesday but a Mac doesn't check in until Wednesday, the date will still be set to that Tuesdays date. Leave parameter blank to disable this feature.
- Added Display Assertion function in addition to maxDisplayAssertionCount variable to set the max amount of times to defer for active display assertion. Leave maxDisplayAssertionCount variable to blank to disable this feature
- Added AAPDisplayAssertionCount to PLIST to use for Extension Attribute/Smart Group to identify Macs with active display assertion deferrals (use case: to scope or a more frequent AAP Trigger until display assertions have ended or max count is reached)