### PR TITLE
Added Variables for Days to Skip and Silent Discovery/Install

### DIFF
--- a/AAP-JamfProEAs/AAP-DaysToSkipCount
+++ b/AAP-JamfProEAs/AAP-DaysToSkipCount
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# This script returns the count of days to skip for App Auto Patch to Jamf inventory. 
+# Make sure to set the Extension Attribute Data Type to "Integer".
+# 04.17.24 @AndrewMBarnett - updated to read from AppAutoPatchStatus.plist
+
+# Path to the App Auto Patch working folder:
+AAP_folder="/Library/Application Support/AppAutoPatch"
+
+# Path to the local property list file:
+AAP_plist="${AAP_folder}/AppAutoPatchStatus.plist"
+
+# Report if the App Auto Patch preference file exists.
+if [[ -f "${AAP_plist}" ]]; then
+    daysToSkipCount=$(defaults read "${AAP_plist}" "AAPDaysToSkipCount" 2> /dev/null)
+    [[ -n "${daysToSkipCount}" ]] && echo "<result>${daysToSkipCount}</result>"
+    [[ -z "${daysToSkipCount}" ]] && echo "<result>No days to skip count</result>"
+else
+    echo "<result>No AAP preference file.</result>"
+fi
+
+exit 0

--- a/App-Auto-Patch-via-Dialog.zsh
+++ b/App-Auto-Patch-via-Dialog.zsh
@@ -1415,7 +1415,7 @@ weeklyPatchingComplete=$(defaults read $appAutoPatchStatusConfigFile AAPWeeklyPa
 weeklyPatchingStatusDate=$(defaults read $appAutoPatchStatusConfigFile AAPWeeklyPatchingStatusDate)
 DisplayAssertionCount=$(defaults read $appAutoPatchStatusConfigFile AAPDisplayAssertionCount)
 DaysToSkipCount=$(defaults read $appAutoPatchStatusConfigFile AAPDaysToSkipCount)
-if [[ -z $weeklyPatchingComplete || -z $weeklyPatchingStatusDate || -z $daysToSkipCount ]]; then
+if [[ -z $weeklyPatchingComplete || -z $weeklyPatchingStatusDate ]]; then
     debug "Patching Completion Status or Start Date not set, setting values"
     defaults write $appAutoPatchStatusConfigFile AAPWeeklyPatching -bool false
     defaults write $appAutoPatchStatusConfigFile AAPWeeklyPatchingStatusDate "$Patch_Week_Start_Date"

--- a/App-Auto-Patch-via-Dialog.zsh
+++ b/App-Auto-Patch-via-Dialog.zsh
@@ -191,7 +191,7 @@ fragmentsPath="$installomatorPath/fragments"
 ### App Auto-Patch Other Behavior Options ###
 
 runDiscovery="true"                                                             # Re-run discovery of installed applications [ true (default) | false ]
-runDiscoverySilent="true"                                                      # Re-run discovery of installed applications silently with no logged in user [ true (default) | false ]
+runDiscoverySilent="false"                                                      # Re-run discovery of installed applications silently with no logged in user [ true | false (default) ]
 removeInstallomatorPath="false"                                                 # Remove Installomator after App Auto-Patch is completed [ true | false (default) ]
 convertAppsInHomeFolder="true"                                                  # Remove apps in /Users/* and install them to do default path [ true (default) | false ]
 ignoreAppsInHomeFolder="false"                                                  # Ignore apps found in '/Users/*'. If an update is found in '/Users/*' and variable is set to `false`, the app will be updated into the application's default path [ true | false (default) ]


### PR DESCRIPTION
Added variable to be able to skip cycles in between swiftDialog deferral prompts if you do not want the deferral window to run everyday but the Jamf policy to continue on a daily cycle.
Added variable to run Discovery and Installs silently.