### PR TITLE
Adds named parameter support

### DIFF
--- a/App-Auto-Patch-via-Dialog.zsh
+++ b/App-Auto-Patch-via-Dialog.zsh
@@ -138,12 +138,65 @@ scriptVersion="2.11.1"
 scriptFunctionalName="App Auto-Patch"
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 
-interactiveMode="${4:="2"}"                                                     # Parameter 4: Interactive Mode [ 0 (Completely Silent) | 1 (Silent Discovery, Interactive Patching) | 2 (Full Interactive) (default) ]
-ignoredLabels="${5:=""}"                                                        # Parameter 5: A space-separated list of Installomator labels to ignore (i.e., "microsoft* googlechrome* jamfconnect zoom* 1password* firefox* swiftdialog")
-requiredLabels="${6:=""}"                                                       # Parameter 6: A space-separated list of required Installomator labels (i.e., "firefoxpkg_intl")
-optionalLabels="${7:=""}"                                                       # Parameter 7: A space-separated list of optional Installomator labels (i.e., "renew") ** Does not support wildcards **
-installomatorOptions="${8:-""}"                                                 # Parameter 8: A space-separated list of options to override default Installomator options (i.e., BLOCKING_PROCESS_ACTION=prompt_user NOTIFY=silent LOGO=appstore)
-maxDeferrals="${9:-"Disabled"}"                                                 # Parameter 9: Number of times a user is allowed to defer before being forced to install updates. A value of "Disabled" will not display the deferral prompt. [ `integer` | Disabled (default) ]
+# Script options (modify these with desired defaults)
+interactive_mode="2"                                                            # Parameter 4: Interactive Mode [ 0 (Completely Silent) | 1 (Silent Discovery, Interactive Patching) | 2 (Full Interactive) (default) ]
+ignored_labels="grammarly"                                                      # Parameter 5: A space-separated list of Installomator labels to ignore (i.e., "microsoft* googlechrome* jamfconnect zoom* 1password* firefox* swiftdialog")
+required_labels=""                                                              # Parameter 6: A space-separated list of required Installomator labels (i.e., "firefoxpkg_intl")
+optional_labels=""                                                              # Parameter 7: A space-separated list of optional Installomator labels (i.e., "renew") ** Does not support wildcards **
+installomator_options="BLOCKING_PROCESS_ACTION=ignore"                          # Parameter 8: A space-separated list of options to override default Installomator options (i.e., BLOCKING_PROCESS_ACTION=prompt_user NOTIFY=silent LOGO=appstore)
+max_deferrals="Disabled"                                                        # Parameter 9: Number of times a user is allowed to defer before being forced to install updates. A value of "Disabled" will not display the deferral prompt. [ `integer` | Disabled (default) ]
+
+# Initialize named parameter variables with default positional values
+interactiveMode="${4:=$interactive_mode}"
+ignoredLabels="${5:=$ignored_labels}"
+requiredLabels="${6:=$required_labels}"
+optionalLabels="${7:=$optional_labels}"
+installomatorOptions="${8:-$installomator_options}"
+maxDeferrals="${9:-$max_deferrals}"
+
+named_parameters=false
+# Parse named parameters
+for arg in "$@"; do
+    case $arg in
+        --interactive_mode=*)
+            interactive_mode="${arg#*=}"
+            named_parameters=true
+            ;;
+        --ignored_labels=*)
+            ignored_labels="${arg#*=}"
+            named_parameters=true
+            ;;
+        --required_labels=*)
+            required_labels="${arg#*=}"
+            named_parameters=true
+            ;;
+        --optional_labels=*)
+            optional_labels="${arg#*=}"
+            named_parameters=true
+            ;;
+        --installomator_options=*)
+            installomator_options="${arg#*=}"
+            named_parameters=true
+            ;;
+        --max_deferrals=*)
+            max_deferrals="${arg#*=}"
+            named_parameters=true
+            ;;
+        *)
+            positional_args+=("$arg")
+            ;;
+    esac
+done
+
+if [[ "$named_parameters" == "true" ]]; then
+    # Apply defaults to named parameters if not overridden
+    interactiveMode="$interactive_mode"
+    ignoredLabels="$ignored_labels"
+    requiredLabels="$required_labels"
+    optionalLabels="$optional_labels"
+    installomatorOptions="$installomator_options"
+    maxDeferrals="$max_deferrals"
+fi
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Various Feature Variables


### PR DESCRIPTION
Adds support for named parameters along with positional parameters.

e.g.

```
App-Auto-Patch-via-Dialog.zsh --interactive_mode=2 --ignored_labels="firefox googlechrome" --required_labels="firefoxpkg_intl" --optional_labels="renew" --installomator_options="DEBUG=2" --max_deferrals=3
```